### PR TITLE
add prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Tool to migrate Prometheus 1.x data directories to the 2.0 format.
 
+## Prerequisites
+
+Golang 1.9 or higher
+
 ## Build
 
 ```


### PR DESCRIPTION
Hello Julius,
When compiling I was on CentOS 7.4 and they are on golang 1.8.3 which was missing the math/bits src by default. I am adding the prereq so at least this would help anyone at a glance.

Thank you for your consideration,
Peter